### PR TITLE
Set transition duration proportionally to the remaining distance

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -331,7 +331,7 @@ var SwipeView = (function(){
 
 			// Check if we exceeded the snap threshold
 			if (dist < this.snapThreshold) {
-				this.slider.style.webkitTransitionDuration = '300ms';
+				this.slider.style.webkitTransitionDuration = Math.floor(300 * dist / this.snapThreshold) + 'ms';
 				this.__pos(-this.page * this.pageWidth);
 				return;
 			}
@@ -380,9 +380,9 @@ var SwipeView = (function(){
 			pageFlipIndex = pageFlipIndex - Math.floor(pageFlipIndex / this.options.numberOfPages) * this.options.numberOfPages;
 			this.masterPages[pageFlip].dataset.upcomingPageIndex = pageFlipIndex;		// Index to be loaded in the newly flipped page
 
-			this.slider.style.webkitTransitionDuration = '500ms';
-			
 			newX = -this.page * this.pageWidth;
+			
+			this.slider.style.webkitTransitionDuration = Math.floor(500 * Math.abs(this.x - newX) / this.pageWidth) + 'ms';
 
 			// Hide the next page if we decided to disable looping
 			if (!this.options.loop) {


### PR DESCRIPTION
This change adjusts the transition duration based on the remaining travel distance; if you slide most of the way before releasing, the transition will snap to its final destination relatively quickly instead of painfully scrolling a few pixels for the full 500ms.
