### PR TITLE
Don't flip direction to zero when mouse/touch is stationary.

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -275,7 +275,9 @@ var SwipeView = (function(){
 			this.moved = true;
 			this.pointX = point.pageX;
 			this.pointY = point.pageY;
-			this.directionX = deltaX > 0 ? 1 : deltaX < 0 ? -1 : 0;
+			if (deltaX !== 0) {
+				this.directionX = deltaX > 0 ? 1 : -1;
+			}
 			this.stepsX += Math.abs(deltaX);
 			this.stepsY += Math.abs(deltaY);
 

--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -320,7 +320,7 @@ var SwipeView = (function(){
 			if (!this.initiated) return;
 			
 			var point = hasTouch ? e.changedTouches[0] : e,
-				dist = Math.abs(point.pageX - this.startX);
+				dist = point.pageX - this.startX;
 
 			this.initiated = false;
 			
@@ -332,8 +332,14 @@ var SwipeView = (function(){
 			}
 
 			// Check if we exceeded the snap threshold
-			if (dist < this.snapThreshold) {
-				this.slider.style.webkitTransitionDuration = Math.floor(300 * dist / this.snapThreshold) + 'ms';
+			if (Math.abs(dist) < this.snapThreshold) {
+				this.slider.style.webkitTransitionDuration = Math.floor(300 * Math.abs(dist) / this.snapThreshold) + 'ms';
+				this.__pos(-this.page * this.pageWidth);
+				return;
+			}
+			// Check if swipe was cancelled by reversing swipe direction
+			if ((dist < 0 && this.directionX >= 0) || (dist > 0 && this.directionX <= 0)) {
+				this.slider.style.webkitTransitionDuration = Math.floor(300 * Math.abs(dist) / this.pageWidth) + 'ms';
 				this.__pos(-this.page * this.pageWidth);
 				return;
 			}


### PR DESCRIPTION
Mousemove/touchmove events keep on firing (once per second or so) even if the pointer position is not changing. This resulted in the direction being reset to zero if one holds the mouse/finger stationary for a while. Since __checkPosition only has a two-way branch, a zero direction always fell into the second branch, resulting in sporadic broken behaviour for backwards (right, positive direction) swipes while forward (left, negative direction) swipes worked perfectly.

Specifically:
1. Swipe backwards (right) past the snap threshold and release immediately, page changes and everything is fine.
2. Swipe backwards (right), hold the mouse steady for a few seconds, then release. Page snaps back to its previous position (in fact, it is being advanced in the wrong direction!), page index is incremented in the wrong direction, and is now out of sync with the displayed page. Future swipes keep the page index off by one.

This is the minimal fix, it would probably make sense to also add a branch in __checkPosition to do the right thing when directionX == 0, since that could still happen when snapThreshold == 0.
