### PR TITLE
Go to page no loop fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "swipeview",
+  "version": "1.0.0",
+  "author": "cubiq",
+  "description": "Virtually infinite loop-able horizontal carousel for desktop and mobile browsers.",
+  "contributors": [ 
+    {
+      "name": "cubiq"
+    } 
+  ],
+  "main": "./src/swipeview",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cubiq/SwipeView.git"
+  },
+  "keywords": [
+    "swipeview",
+    "swipe",
+    "transition"
+  ],
+  "license": "MIT"
+}

--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -222,8 +222,13 @@ var SwipeView = (function (window, document) {
 				this.masterPages[2].dataset.upcomingPageIndex = this.page;
 				this.masterPages[0].dataset.upcomingPageIndex = this.page == this.options.numberOfPages-1 ? 0 : this.page + 1;
 			}
-			
+
 			this.__flip();
+			// Hide the next page if we decided to disable looping
+			if (!this.options.loop) {
+				this.masterPages[0].style.visibility = '';
+				this.__checkPosition();
+			}
 		},
 		
 		next: function () {


### PR DESCRIPTION
If you disable looping and use a goToPage the masterPage 0 will stay as invisible but potentially the next page will be visible (which shouldn't) I didn't fully understand the system but removing the visibility hidden and rechecking the position seems to fix the situation.
