### PR TITLE
make on touch offset available

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -66,7 +66,8 @@ var SwipeView = (function (window, document) {
 				numberOfPages: 3,
 				snapThreshold: null,
 				hastyPageFlip: false,
-				loop: true
+				loop: true,
+				touchOffset: [0, 0]
 			};
 		
 			// User defined options
@@ -176,6 +177,10 @@ var SwipeView = (function (window, document) {
 		updatePageCount: function (n) {
 			this.options.numberOfPages = n;
 			this.maxX = -this.options.numberOfPages * this.pageWidth + this.wrapperWidth;
+		},
+
+		updateTouchOffset: function (x, y) {
+			this.options.touchOffset = [x, y];
 		},
 		
 		goToPage: function (p) {
@@ -291,14 +296,15 @@ var SwipeView = (function (window, document) {
 			this.initiated = true;
 			this.moved = false;
 			this.thresholdExceeded = false;
-			this.startX = point.pageX;
-			this.startY = point.pageY;
-			this.pointX = point.pageX;
-			this.pointY = point.pageY;
+			this.startX = point.pageX - this.options.touchOffset[0];
+			this.startY = point.pageY - this.options.touchOffset[1];
+			this.pointX = point.pageX - this.options.touchOffset[0];
+			this.pointY = point.pageY - this.options.touchOffset[1];
 			this.stepsX = 0;
 			this.stepsY = 0;
 			this.directionX = 0;
 			this.directionLocked = false;
+			this.updateTouchOffset(0, 0);
 			
 /*			var matrix = getComputedStyle(this.slider, null).webkitTransform.replace(/[^0-9-.,]/g, '').split(',');
 			this.x = matrix[4] * 1;*/


### PR DESCRIPTION
We implemented a feature that once you scroll down, the boxes left and right were moved down also with margin top. This made it possible to swipe left or right on a downscrolled page. You then were on top of the page you swiped to. Once you scroll again I have to reset the margin and scroll to 0,0 so you don't see the huge margin on top of the Container. This caused the problem that you couldn't swipe anymore for the first touchstart event.

The reason for this is that once I move the container, the difference between the startPoint and the currentPoint of the event is so big that the direction detection is already triggered. To prevent that I implemented an offset which is used once after it's set.

Now you can just call 

swipeView.updateTouchOffset(0, window.pageYOffset);

to make the update the event coordinates for the next swipe

Ping me if you have any questions
