### PR TITLE
Options to set explicitly wrapper width and height added. Fixes #45

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -162,8 +162,8 @@ var SwipeView = (function (window, document) {
 		},
 
 		refreshSize: function () {
-			this.wrapperWidth = this.wrapper.clientWidth;
-			this.wrapperHeight = this.wrapper.clientHeight;
+			this.wrapperWidth = this.options.wrapperWidth || this.wrapper.clientWidth;
+			this.wrapperHeight = this.options.wrapperHeight || this.wrapper.clientHeight;
 			this.pageWidth = this.wrapperWidth;
 			this.maxX = -this.options.numberOfPages * this.pageWidth + this.wrapperWidth;
 			this.snapThreshold = this.options.snapThreshold === null ?


### PR DESCRIPTION
Hi cubiq,

just found a solution to issue #45. 
When a new Swipeview object is instantiated and the html wrapper element is not rendered, you can prevent wrapper size to be === 0 setting explicitly `wrapperWidth` and `wrapperHeight` options. 

I think it’d be worthwhile to pull it into the project repository.

Thanks!
