### PR TITLE
Allow normal right-click on gallery demo images

### DIFF
--- a/demo/gallery/index.html
+++ b/demo/gallery/index.html
@@ -76,6 +76,7 @@ gallery = new SwipeView('#wrapper', { numberOfPages: slides.length });
 for (i=0; i<3; i++) {
 	page = i==0 ? slides.length-1 : i-1;
 	el = document.createElement('img');
+	el.draggable = false;
 	el.className = 'loading';
 	el.src = slides[page].img;
 	el.width = slides[page].width;

--- a/demo/gallery/style.css
+++ b/demo/gallery/style.css
@@ -121,7 +121,6 @@ body {
 	-o-transition-property:opacity;
 	transition-property:opacity;
 	opacity:1;
-	pointer-events:none;
 }
 
 #swipeview-slider span {


### PR DESCRIPTION
Using "pointer-events:none;" disables normal right-click event. Instead
use "draggable='false'" on img-tag to allow both swiping and right-click
events.
