### PR TITLE
Add trigger for when the slider starts moving, before movein/moveout.

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -127,7 +127,12 @@ var SwipeView = (function (window, document) {
 			this.wrapper.addEventListener('swipeview-flip', fn, false);
 			this.customEvents.push(['flip', fn]);
 		},
-		
+
+		onMove: function (fn) {
+			this.wrapper.addEventListener('swipeview-move', fn, false);
+			this.customEvents.push(['move', fn]);
+		},
+
 		onMoveOut: function (fn) {
 			this.wrapper.addEventListener('swipeview-moveout', fn, false);
 			this.customEvents.push(['moveout', fn]);
@@ -339,6 +344,8 @@ var SwipeView = (function (window, document) {
 			e.preventDefault();
 
 			this.directionLocked = true;
+
+			this.__event('move');
 
 			if (!this.options.loop && (newX > 0 || newX < this.maxX)) {
 				newX = this.x + (deltaX / 2);


### PR DESCRIPTION
Trigger 'move' and call onMove callbacks as soon as slider moves. In other words, when directionLocked gets set to true in the method that runs on 'touchmove'. This allows code to run as soon as SwipeView starts moving the pages.
