### PR TITLE
Added a function for swipeview to return it's current page

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -160,7 +160,9 @@ var SwipeView = (function (window, document) {
 				this.wrapper.removeEventListener('mouseout', this, false);
 			}*/
 		},
-
+		getCurrentPage: function(){
+			return this.pageIndex;
+		},
 		refreshSize: function () {
 			this.wrapperWidth = this.wrapper.clientWidth;
 			this.wrapperHeight = this.wrapper.clientHeight;


### PR DESCRIPTION
I noticed that a very simple functionality was missing from your slider. I added a function which returns the current page index so that people can get that information directly from their SwipeView object using 

> swpview.getCurrentPage()

This makes it far easier to give the user visual clues as to where the slider is if the developer wants to utilize that.
