### PR TITLE
Updated patch from #34 for goToPage issue with loop: false

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -224,6 +224,22 @@ var SwipeView = (function (window, document) {
 			}
 			
 			this.__flip();
+
+			// Hide the next page if we decided to disable looping
+			if (!this.options.loop) {
+				//reset all pages visibillity
+				this.masterPages[0].style.visibility = '';
+				this.masterPages[1].style.visibility = '';
+				this.masterPages[2].style.visibility = '';
+				//if current page firs or last we get number of masterpage an hide it
+				if (this.page === 0) {
+					this.masterPages[0].style.visibility = 'hidden';
+				}
+				if (this.page == this.options.numberOfPages - 1) {
+					nextPage = this.currentMasterPage <= 1 ? this.currentMasterPage + 1 : 0;
+					this.masterPages[nextPage].style.visibility = 'hidden';
+				}
+			}
 		},
 		
 		next: function () {


### PR DESCRIPTION
This patch fixes several issues relating to `goToPage()` where `loop: false`. 

If you disable looping and use a `goToPage()` the `masterPage` 0 will stay as invisible but potentially the next page will be visible (which shouldn't). Similarly, `goToPage(2)` would result in the destination page being hidden.

This pull request supersedes #34 and consists of the solution to provided by @linlex, which has been confirmed to work.
