### PR TITLE
Fix for #29; instant snap back when looping: false

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -363,19 +363,19 @@ var SwipeView = (function (window, document) {
 			if (!this.initiated) return;
 			
 			var point = hasTouch ? e.changedTouches[0] : e,
-				dist = Math.abs(point.pageX - this.startX);
+				dist = Math.abs(point.pageX - this.startX),
+				movein = !this.options.loop && (this.x > 0 || this.x < this.maxX);
 
 			this.initiated = false;
 			
 			if (!this.moved) return;
 
-			if (!this.options.loop && (this.x > 0 || this.x < this.maxX)) {
-				dist = 0;
+			if (movein) {
 				this.__event('movein');
 			}
 
 			// Check if we exceeded the snap threshold
-			if (dist < this.snapThreshold) {
+			if (dist < this.snapThreshold || movein) {
 				this.slider.style[transitionDuration] = Math.floor(300 * dist / this.snapThreshold) + 'ms';
 				this.__pos(-this.page * this.pageWidth);
 				return;


### PR DESCRIPTION
Based on the suggestions in #29, I have removed `dist = 0` around line 373 which seems to have been used in the `if` statement later on. Instead, I have assigned the condition to a variable and have OR'ed that with the original condition.

This _seems_ to work for me but I would _love_ additional feedback from the original participants in the issue report (@ghost, @MathieuLoutre and @linlex).
