### PR TITLE
wrapperWidth, wrapperHeight options

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -162,8 +162,8 @@ var SwipeView = (function (window, document) {
 		},
 
 		refreshSize: function () {
-			this.wrapperWidth = this.wrapper.clientWidth;
-			this.wrapperHeight = this.wrapper.clientHeight;
+			this.wrapperWidth = this.options.wrapperWidth || this.wrapper.clientWidth;
+			this.wrapperHeight = this.options.wrapperHeight || this.wrapper.clientHeight;
 			this.pageWidth = this.wrapperWidth;
 			this.maxX = -this.options.numberOfPages * this.pageWidth + this.wrapperWidth;
 			this.snapThreshold = this.options.snapThreshold === null ?


### PR DESCRIPTION
add option to pass in wrapperWidth and wrapperHeight

this fixes some issues I was having when using this plugin with cordova, clientWidth and clientHeight weren't available at the right time which caused errors
